### PR TITLE
Enable explicitly specifying which protocol to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > A LibP2P wrapper for hashicorp/raft implementation.
 
-`go-libp2p-raft` implements a go-libp2p-consensus interface wrapping hashicorp/raftimplementation and providing a libp2p network transport for it.
+`go-libp2p-raft` implements a go-libp2p-consensus interface wrapping hashicorp/raft implementation and providing a libp2p network transport for it.
 
 ## Table of Contents
 


### PR DESCRIPTION
In a scenario where a single node might need to participate in multiple Raft clusters at the same time, it can be useful to be able to explicitly specify the protocol that should be used. That way something like the cluster ID can be used as part of the protocol identifier and have the muxer split the messages belonging to the transport stream of each individual Raft cluster.